### PR TITLE
Move blanket tokens from foundations to component

### DIFF
--- a/src/Blanket/Tokens/tokens.ts
+++ b/src/Blanket/Tokens/tokens.ts
@@ -1,0 +1,9 @@
+import { inube } from "@inubekit/foundations";
+
+const tokens = {
+  background: {
+    color: inube.palette.neutralAlpha.N100A,
+  },
+};
+
+export { tokens };

--- a/src/Blanket/stories/styles.js
+++ b/src/Blanket/stories/styles.js
@@ -1,5 +1,6 @@
 import styled from "styled-components";
 import { inube } from "@inubekit/foundations";
+import { tokens } from "../Tokens/tokens";
 
 const StyledBackdropBlanket = styled.div`
   position: fixed;
@@ -17,15 +18,15 @@ const StyledButton = styled.button`
   width: fit-content;
   padding-left: 16px;
   padding-right: 16px;
-  background-color: ${inube.blanket.background.color};
+  background-color: ${tokens.background.color};
   font-family: ${inube.typography.body.large.font};
   font-size: ${inube.typography.body.large.size};
   font-weight: ${inube.typography.body.large.weight};
   line-height: ${inube.typography.body.large.lineHeight};
-  color: ${inube.blanket.background.color};
+  color: ${tokens.background.color};
 
   &:hover {
-    background-color: ${inube.blanket.background.color};
+    background-color: ${tokens.background.color};
   }
 `;
 

--- a/src/Blanket/styles.js
+++ b/src/Blanket/styles.js
@@ -1,5 +1,5 @@
 import styled from "styled-components";
-import { inube } from "@inubekit/foundations";
+import { tokens } from "./Tokens/tokens";
 
 const StyledBlanket = styled.div`
   position: fixed;
@@ -8,7 +8,7 @@ const StyledBlanket = styled.div`
     $isSmallScreen ? "center" : "initial"};
   inset: 0;
   background-color: ${({ theme }) =>
-    theme?.blanket?.background?.color || inube.blanket.background.color};
+    theme?.blanket?.background?.color || tokens.background.color};
   border: none;
   z-index: 1;
   overflow-y: auto;


### PR DESCRIPTION
This PR relocates the blanket tokens from the foundations folder to the respective component folder, updating all relevant imports to reflect the new structure and ensuring components are referencing the correct token paths. This refactor enhances the modularity, maintainability, and clarity of the codebase.